### PR TITLE
add improved move screen and other QOL

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -41,3 +41,4 @@ The following keeps track of specific credits for assets and features.
 - [Display more information on the move screen](https://github.com/pret/pokecrystal/wiki/Display-more-information-on-the-move-screen)
 - [Make new battle text to distinguish status move misses and fails](https://github.com/pret/pokecrystal/wiki/Make-new-battle-text-to-distinguish-status-move-misses-and-fails)
 - [Prevent Steel‐types from being poisoned by Twineedle](https://github.com/pret/pokecrystal/wiki/Prevent-Steel%E2%80%90types-from-being-poisoned-by-Twineedle)
+- [Remove the 25% failure chance for AI status moves](https://github.com/pret/pokecrystal/wiki/Remove-the-25%25-failure-chance-for-AI-status-moves)

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -38,3 +38,4 @@ The following keeps track of specific credits for assets and features.
 - [Show an icon for the current weather](https://github.com/pret/pokecrystal/wiki/Show-an-icon-for-the-current-weather)
 - [Add a new item](https://github.com/pret/pokecrystal/wiki/Add-a-new-item)
 - [Adding an NPC that gives you an item](https://github.com/pret/pokecrystal/wiki/Adding-an-NPC-that-gives-you-an-item)
+- [Display more information on the move screen](https://github.com/pret/pokecrystal/wiki/Display-more-information-on-the-move-screen)

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -40,3 +40,4 @@ The following keeps track of specific credits for assets and features.
 - [Adding an NPC that gives you an item](https://github.com/pret/pokecrystal/wiki/Adding-an-NPC-that-gives-you-an-item)
 - [Display more information on the move screen](https://github.com/pret/pokecrystal/wiki/Display-more-information-on-the-move-screen)
 - [Make new battle text to distinguish status move misses and fails](https://github.com/pret/pokecrystal/wiki/Make-new-battle-text-to-distinguish-status-move-misses-and-fails)
+- [Prevent Steel‐types from being poisoned by Twineedle](https://github.com/pret/pokecrystal/wiki/Prevent-Steel%E2%80%90types-from-being-poisoned-by-Twineedle)

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -39,3 +39,4 @@ The following keeps track of specific credits for assets and features.
 - [Add a new item](https://github.com/pret/pokecrystal/wiki/Add-a-new-item)
 - [Adding an NPC that gives you an item](https://github.com/pret/pokecrystal/wiki/Adding-an-NPC-that-gives-you-an-item)
 - [Display more information on the move screen](https://github.com/pret/pokecrystal/wiki/Display-more-information-on-the-move-screen)
+- [Make new battle text to distinguish status move misses and fails](https://github.com/pret/pokecrystal/wiki/Make-new-battle-text-to-distinguish-status-move-misses-and-fails)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -41,6 +41,7 @@ This document is a living checklist outlining the items needed to be complete pr
 - [x] Dynamic battle palette
 - [x] Nayru's PokeDex
 - [x] Improved move screen
+- [ ] Improve battle AI
 
 ## Stretch Goals
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -40,6 +40,7 @@ This document is a living checklist outlining the items needed to be complete pr
 - [x] Increase shiny odds to 1/4096
 - [x] Dynamic battle palette
 - [x] Nayru's PokeDex
+- [x] Improved move screen
 
 ## Stretch Goals
 

--- a/data/moves/descriptions.asm
+++ b/data/moves/descriptions.asm
@@ -263,1004 +263,1004 @@ InvalidMoveDescription:
 
 PoundDescription:
 	db   "Pounds with fore-"
-	next "legs or tail.@"
+	line "legs or tail.@"
 
 KarateChopDescription:
 	db   "Has a high criti-"
-	next "cal hit ratio.@"
+	line "cal hit ratio.@"
 
 DoubleslapDescription:
 	db   "Repeatedly slaps"
-	next "2-5 times.@"
+	line "2-5 times.@"
 
 CometPunchDescription:
 	db   "Repeatedly punches"
-	next "2-5 times.@"
+	line "2-5 times.@"
 
 MegaPunchDescription:
 	db   "A powerful punch"
-	next "thrown very hard.@"
+	line "thrown very hard.@"
 
 PayDayDescription:
 	db   "Throws coins. Gets"
-	next "them back later.@"
+	line "them back later.@"
 
 FirePunchDescription:
 	db   "A fiery punch. May"
-	next "cause a burn.@"
+	line "cause a burn.@"
 
 IcePunchDescription:
 	db   "An icy punch. May"
-	next "cause freezing.@"
+	line "cause freezing.@"
 
 ThunderpunchDescription:
 	db   "An electric punch."
-	next "It may paralyze.@"
+	line "It may paralyze.@"
 
 ScratchDescription:
 	db   "Scratches with"
-	next "sharp claws.@"
+	line "sharp claws.@"
 
 VicegripDescription:
 	db   "Grips with power-"
-	next "ful pincers.@"
+	line "ful pincers.@"
 
 GuillotineDescription:
 	db   "A one-hit KO,"
-	next "pincer attack.@"
+	line "pincer attack.@"
 
 RazorWindDescription:
 	db   "1st turn: Prepare"
-	next "2nd turn: Attack@"
+	line "2nd turn: Attack@"
 
 SwordsDanceDescription:
 	db   "A dance that in-"
-	next "creases ATTACK.@"
+	line "creases ATTACK.@"
 
 CutDescription:
 	db   "Cuts using claws,"
-	next "scythes, etc.@"
+	line "scythes, etc.@"
 
 GustDescription:
 	db   "Whips up a strong"
-	next "gust of wind.@"
+	line "gust of wind.@"
 
 WingAttackDescription:
 	db   "Strikes the target"
-	next "with wings.@"
+	line "with wings.@"
 
 WhirlwindDescription:
 	db   "Blows away the foe"
-	next "& ends battle.@"
+	line "& ends battle.@"
 
 FlyDescription:
 	db   "1st turn: Fly"
-	next "2nd turn: Attack@"
+	line "2nd turn: Attack@"
 
 BindDescription:
 	db   "Binds the target"
-	next "for 2-5 turns.@"
+	line "for 2-5 turns.@"
 
 SlamDescription:
 	db   "Slams the foe with"
-	next "a tail, vine, etc.@"
+	line "a tail, vine, etc.@"
 
 VineWhipDescription:
 	db   "Whips the foe with"
-	next "slender vines.@"
+	line "slender vines.@"
 
 StompDescription:
 	db   "An attack that may"
-	next "cause flinching.@"
+	line "cause flinching.@"
 
 DoubleKickDescription:
 	db   "A double kicking"
-	next "attack.@"
+	line "attack.@"
 
 MegaKickDescription:
 	db   "A powerful kicking"
-	next "attack.@"
+	line "attack.@"
 
 JumpKickDescription:
 	db   "May miss, damaging"
-	next "the user.@"
+	line "the user.@"
 
 RollingKickDescription:
 	db   "A fast, spinning"
-	next "kick.@"
+	line "kick.@"
 
 SandAttackDescription:
 	db   "Reduces accuracy"
-	next "by throwing sand.@"
+	line "by throwing sand.@"
 
 HeadbuttDescription:
 	db   "An attack that may"
-	next "make foe flinch.@"
+	line "make foe flinch.@"
 
 HornAttackDescription:
 	db   "An attack using a"
-	next "horn to jab.@"
+	line "horn to jab.@"
 
 FuryAttackDescription:
 	db   "Jabs the target"
-	next "2-5 times.@"
+	line "2-5 times.@"
 
 HornDrillDescription:
 	db   "A one-hit KO,"
-	next "drill attack.@"
+	line "drill attack.@"
 
 TackleDescription:
 	db   "A full-body charge"
-	next "attack.@"
+	line "attack.@"
 
 BodySlamDescription:
 	db   "An attack that may"
-	next "cause paralysis.@"
+	line "cause paralysis.@"
 
 WrapDescription:
 	db   "Squeezes the foe"
-	next "for 2-5 turns.@"
+	line "for 2-5 turns.@"
 
 TakeDownDescription:
 	db   "A tackle that also"
-	next "hurts the user.@"
+	line "hurts the user.@"
 
 ThrashDescription:
 	db   "Works 2-3 turns"
-	next "and confuses user.@"
+	line "and confuses user.@"
 
 DoubleEdgeDescription:
 	db   "A tackle that also"
-	next "hurts the user.@"
+	line "hurts the user.@"
 
 TailWhipDescription:
 	db   "Lowers the foe's"
-	next "DEFENSE.@"
+	line "DEFENSE.@"
 
 PoisonStingDescription:
 	db   "An attack that may"
-	next "poison the target.@"
+	line "poison the target.@"
 
 TwineedleDescription:
 	db   "Jabs the foe twice"
-	next "using stingers.@"
+	line "using stingers.@"
 
 PinMissileDescription:
 	db   "Fires pins that"
-	next "strike 2-5 times.@"
+	line "strike 2-5 times.@"
 
 LeerDescription:
 	db   "Reduces the foe's"
-	next "DEFENSE.@"
+	line "DEFENSE.@"
 
 BiteDescription:
 	db   "An attack that may"
-	next "cause flinching.@"
+	line "cause flinching.@"
 
 GrowlDescription:
 	db   "Reduces the foe's"
-	next "ATTACK.@"
+	line "ATTACK.@"
 
 RoarDescription:
 	db   "Scares wild foes"
-	next "to end battle.@"
+	line "to end battle.@"
 
 SingDescription:
 	db   "May cause the foe"
-	next "to fall asleep.@"
+	line "to fall asleep.@"
 
 SupersonicDescription:
 	db   "Sound waves that"
-	next "cause confusion.@"
+	line "cause confusion.@"
 
 SonicboomDescription:
 	db   "Always inflicts"
-	next "20HP damage.@"
+	line "20HP damage.@"
 
 DisableDescription:
 	db   "Disables the foe's"
-	next "most recent move.@"
+	line "most recent move.@"
 
 AcidDescription:
 	db   "An attack that may"
-	next "lower DEFENSE.@"
+	line "lower DEFENSE.@"
 
 EmberDescription:
 	db   "An attack that may"
-	next "inflict a burn.@"
+	line "inflict a burn.@"
 
 FlamethrowerDescription:
 	db   "An attack that may"
-	next "inflict a burn.@"
+	line "inflict a burn.@"
 
 MistDescription:
 	db   "Prevents stat"
-	next "reduction.@"
+	line "reduction.@"
 
 WaterGunDescription:
 	db   "Squirts water to"
-	next "attack.@"
+	line "attack.@"
 
 HydroPumpDescription:
 	db   "A powerful water-"
-	next "type attack.@"
+	line "type attack.@"
 
 SurfDescription:
 	db   "A strong water-"
-	next "type attack.@"
+	line "type attack.@"
 
 IceBeamDescription:
 	db   "An attack that may"
-	next "freeze the foe.@"
+	line "freeze the foe.@"
 
 BlizzardDescription:
 	db   "An attack that may"
-	next "freeze the foe.@"
+	line "freeze the foe.@"
 
 PsybeamDescription:
 	db   "An attack that may"
-	next "confuse the foe.@"
+	line "confuse the foe.@"
 
 BubblebeamDescription:
 	db   "An attack that may"
-	next "lower SPEED.@"
+	line "lower SPEED.@"
 
 AuroraBeamDescription:
 	db   "An attack that may"
-	next "lower ATTACK.@"
+	line "lower ATTACK.@"
 
 HyperBeamDescription:
 	db   "1st turn: Attack"
-	next "2nd turn: Rest@"
+	line "2nd turn: Rest@"
 
 PeckDescription:
 	db   "Jabs the foe with"
-	next "a beak, etc.@"
+	line "a beak, etc.@"
 
 DrillPeckDescription:
 	db   "A strong, spin-"
-	next "ning-peck attack.@"
+	line "ning-peck attack.@"
 
 SubmissionDescription:
 	db   "An attack that al-"
-	next "so hurts the user.@"
+	line "so hurts the user.@"
 
 LowKickDescription:
 	db   "An attack that may"
-	next "cause flinching.@"
+	line "cause flinching.@"
 
 CounterDescription:
 	db   "Returns a physical"
-	next "blow double.@"
+	line "blow double.@"
 
 SeismicTossDescription:
 	db   "The user's level"
-	next "equals damage HP.@"
+	line "equals damage HP.@"
 
 StrengthDescription:
 	db   "A powerful physi-"
-	next "cal attack.@"
+	line "cal attack.@"
 
 AbsorbDescription:
 	db   "Steals 1/2 of the"
-	next "damage inflicted.@"
+	line "damage inflicted.@"
 
 MegaDrainDescription:
 	db   "Steals 1/2 of the"
-	next "damage inflicted.@"
+	line "damage inflicted.@"
 
 LeechSeedDescription:
 	db   "Steals HP from the"
-	next "foe on every turn.@"
+	line "foe on every turn.@"
 
 GrowthDescription:
 	db   "Raises the SPCL."
-	next "ATK rating.@"
+	line "ATK rating.@"
 
 RazorLeafDescription:
 	db   "Has a high criti-"
-	next "cal hit ratio.@"
+	line "cal hit ratio.@"
 
 SolarbeamDescription:
 	db   "1st turn: Prepare"
-	next "2nd turn: Attack@"
+	line "2nd turn: Attack@"
 
 PoisonpowderDescription:
 	db   "A move that may"
-	next "poison the foe.@"
+	line "poison the foe.@"
 
 StunSporeDescription:
 	db   "A move that may"
-	next "paralyze the foe.@"
+	line "paralyze the foe.@"
 
 SleepPowderDescription:
 	db   "May cause the foe"
-	next "to fall asleep.@"
+	line "to fall asleep.@"
 
 PetalDanceDescription:
 	db   "Works 2-3 turns"
-	next "and confuses user.@"
+	line "and confuses user.@"
 
 StringShotDescription:
 	db   "A move that lowers"
-	next "the foe's SPEED.@"
+	line "the foe's SPEED.@"
 
 DragonRageDescription:
 	db   "Always inflicts"
-	next "40HP damage.@"
+	line "40HP damage.@"
 
 FireSpinDescription:
 	db   "Traps foe in fire"
-	next "for 2-5 turns.@"
+	line "for 2-5 turns.@"
 
 ThundershockDescription:
 	db   "An attack that may"
-	next "cause paralysis.@"
+	line "cause paralysis.@"
 
 ThunderboltDescription:
 	db   "An attack that may"
-	next "cause paralysis.@"
+	line "cause paralysis.@"
 
 ThunderWaveDescription:
 	db   "A move that may"
-	next "cause paralysis.@"
+	line "cause paralysis.@"
 
 ThunderDescription:
 	db   "An attack that may"
-	next "cause paralysis.@"
+	line "cause paralysis.@"
 
 RockThrowDescription:
 	db   "Drops rocks on the"
-	next "enemy.@"
+	line "enemy.@"
 
 EarthquakeDescription:
 	db   "Tough but useless"
-	next "vs. flying foes.@"
+	line "vs. flying foes.@"
 
 FissureDescription:
 	db   "A ground-type,"
-	next "one-hit KO attack.@"
+	line "one-hit KO attack.@"
 
 DigDescription:
 	db   "1st turn: Burrow"
-	next "2nd turn: Attack@"
+	line "2nd turn: Attack@"
 
 ToxicDescription:
 	db   "A poison move with"
-	next "increasing damage.@"
+	line "increasing damage.@"
 
 ConfusionDescription:
 	db   "An attack that may"
-	next "cause confusion.@"
+	line "cause confusion.@"
 
 PsychicMDescription:
 	db   "An attack that may"
-	next "lower SPCL.DEF.@"
+	line "lower SPCL.DEF.@"
 
 HypnosisDescription:
 	db   "May put the foe to"
-	next "sleep.@"
+	line "sleep.@"
 
 MeditateDescription:
 	db   "Raises the user's"
-	next "ATTACK.@"
+	line "ATTACK.@"
 
 AgilityDescription:
 	db   "Sharply increases"
-	next "the user's SPEED.@"
+	line "the user's SPEED.@"
 
 QuickAttackDescription:
 	db   "Lets the user get"
-	next "in the first hit.@"
+	line "in the first hit.@"
 
 RageDescription:
 	db   "Raises ATTACK if"
-	next "the user is hit.@"
+	line "the user is hit.@"
 
 TeleportDescription:
 	db   "A move for fleeing"
-	next "from battle.@"
+	line "from battle.@"
 
 NightShadeDescription:
 	db   "The user's level"
-	next "equals damage HP.@"
+	line "equals damage HP.@"
 
 MimicDescription:
 	db   "Copies a move used"
-	next "by the foe.@"
+	line "by the foe.@"
 
 ScreechDescription:
 	db   "Sharply reduces"
-	next "the foe's DEFENSE.@"
+	line "the foe's DEFENSE.@"
 
 DoubleTeamDescription:
 	db   "Heightens evasive-"
-	next "ness.@"
+	line "ness.@"
 
 RecoverDescription:
 	db   "Restores HP by 1/2"
-	next "the max HP.@"
+	line "the max HP.@"
 
 HardenDescription:
 	db   "Raises the user's"
-	next "DEFENSE.@"
+	line "DEFENSE.@"
 
 MinimizeDescription:
 	db   "Heightens evasive-"
-	next "ness.@"
+	line "ness.@"
 
 SmokescreenDescription:
 	db   "Lowers the foe's"
-	next "accuracy.@"
+	line "accuracy.@"
 
 ConfuseRayDescription:
 	db   "A move that causes"
-	next "confusion.@"
+	line "confusion.@"
 
 WithdrawDescription:
 	db   "Heightens the"
-	next "user's DEFENSE.@"
+	line "user's DEFENSE.@"
 
 DefenseCurlDescription:
 	db   "Heightens the"
-	next "user's DEFENSE.@"
+	line "user's DEFENSE.@"
 
 BarrierDescription:
 	db   "Sharply increases"
-	next "user's DEFENSE.@"
+	line "user's DEFENSE.@"
 
 LightScreenDescription:
 	db   "Ups SPCL.DEF with"
-	next "a wall of light.@"
+	line "a wall of light.@"
 
 HazeDescription:
 	db   "Eliminates all"
-	next "stat changes.@"
+	line "stat changes.@"
 
 ReflectDescription:
 	db   "Raises DEFENSE"
-	next "with a barrier.@"
+	line "with a barrier.@"
 
 FocusEnergyDescription:
 	db   "Raises the criti-"
-	next "cal hit ratio.@"
+	line "cal hit ratio.@"
 
 BideDescription:
 	db   "Waits 2-3 turns &"
-	next "hits back double.@"
+	line "hits back double.@"
 
 MetronomeDescription:
 	db   "Randomly uses any"
-	next "#MON move.@"
+	line "#MON move.@"
 
 MirrorMoveDescription:
 	db   "Counters with the"
-	next "same move.@"
+	line "same move.@"
 
 SelfdestructDescription:
 	db   "Powerful but makes"
-	next "the user faint.@"
+	line "the user faint.@"
 
 EggBombDescription:
 	db   "Eggs are hurled at"
-	next "the foe.@"
+	line "the foe.@"
 
 LickDescription:
 	db   "An attack that may"
-	next "cause paralysis.@"
+	line "cause paralysis.@"
 
 SmogDescription:
 	db   "An attack that may"
-	next "poison the foe.@"
+	line "poison the foe.@"
 
 SludgeDescription:
 	db   "An attack that may"
-	next "poison the foe.@"
+	line "poison the foe.@"
 
 BoneClubDescription:
 	db   "An attack that may"
-	next "cause flinching.@"
+	line "cause flinching.@"
 
 FireBlastDescription:
 	db   "An attack that"
-	next "may cause a burn.@"
+	line "may cause a burn.@"
 
 WaterfallDescription:
 	db   "An aquatic charge"
-	next "attack.@"
+	line "attack.@"
 
 ClampDescription:
 	db   "Traps the foe for"
-	next "2-5 turns.@"
+	line "2-5 turns.@"
 
 SwiftDescription:
 	db   "An attack that"
-	next "never misses.@"
+	line "never misses.@"
 
 SkullBashDescription:
 	db   "1st turn: Prepare"
-	next "2nd turn: Attack@"
+	line "2nd turn: Attack@"
 
 SpikeCannonDescription:
 	db   "Fires spikes to"
-	next "hit 2-5 times.@"
+	line "hit 2-5 times.@"
 
 ConstrictDescription:
 	db   "An attack that may"
-	next "lower SPEED.@"
+	line "lower SPEED.@"
 
 AmnesiaDescription:
 	db   "Sharply raises the"
-	next "user's SPCL.DEF.@"
+	line "user's SPCL.DEF.@"
 
 KinesisDescription:
 	db   "Reduces the foe's"
-	next "accuracy.@"
+	line "accuracy.@"
 
 SoftboiledDescription:
 	db   "Restores HP by 1/2"
-	next "the user's max HP.@"
+	line "the user's max HP.@"
 
 HiJumpKickDescription:
 	db   "May miss and hurt"
-	next "the user.@"
+	line "the user.@"
 
 GlareDescription:
 	db   "A move that may"
-	next "cause paralysis.@"
+	line "cause paralysis.@"
 
 DreamEaterDescription:
 	db   "Steals HP from a"
-	next "sleeping victim.@"
+	line "sleeping victim.@"
 
 PoisonGasDescription:
 	db   "A move that may"
-	next "poison the foe.@"
+	line "poison the foe.@"
 
 BarrageDescription:
 	db   "Throws orbs to hit"
-	next "2-5 times.@"
+	line "2-5 times.@"
 
 LeechLifeDescription:
 	db   "Steals 1/2 of the"
-	next "damage inflicted.@"
+	line "damage inflicted.@"
 
 LovelyKissDescription:
 	db   "May cause the foe"
-	next "to fall asleep.@"
+	line "to fall asleep.@"
 
 SkyAttackDescription:
 	db   "1st turn: Prepare"
-	next "2nd turn: Attack@"
+	line "2nd turn: Attack@"
 
 TransformDescription:
 	db   "The user assumes"
-	next "the foe's guise.@"
+	line "the foe's guise.@"
 
 BubbleDescription:
 	db   "An attack that may"
-	next "reduce SPEED.@"
+	line "reduce SPEED.@"
 
 DizzyPunchDescription:
 	db   "An attack that may"
-	next "cause confusion.@"
+	line "cause confusion.@"
 
 SporeDescription:
 	db   "A move that"
-	next "induces sleep.@"
+	line "induces sleep.@"
 
 FlashDescription:
 	db   "Blinds the foe to"
-	next "reduce accuracy.@"
+	line "reduce accuracy.@"
 
 PsywaveDescription:
 	db   "An attack with"
-	next "variable power.@"
+	line "variable power.@"
 
 SplashDescription:
 	db   "Has no effect"
-	next "whatsoever.@"
+	line "whatsoever.@"
 
 AcidArmorDescription:
 	db   "Sharply raises the"
-	next "user's DEFENSE.@"
+	line "user's DEFENSE.@"
 
 CrabhammerDescription:
 	db   "Has a high criti-"
-	next "cal hit ratio.@"
+	line "cal hit ratio.@"
 
 ExplosionDescription:
 	db   "Very powerful but"
-	next "makes user faint.@"
+	line "makes user faint.@"
 
 FurySwipesDescription:
 	db   "Quickly scratches"
-	next "2-5 times.@"
+	line "2-5 times.@"
 
 BonemerangDescription:
 	db   "An attack that"
-	next "strikes twice.@"
+	line "strikes twice.@"
 
 RestDescription:
 	db   "Sleep for 2 turns"
-	next "to fully recover.@"
+	line "to fully recover.@"
 
 RockSlideDescription:
 	db   "An attack that may"
-	next "cause flinching.@"
+	line "cause flinching.@"
 
 HyperFangDescription:
 	db   "An attack that may"
-	next "cause flinching.@"
+	line "cause flinching.@"
 
 SharpenDescription:
 	db   "A move that raises"
-	next "the user's ATTACK.@"
+	line "the user's ATTACK.@"
 
 ConversionDescription:
 	db   "Change user's type"
-	next "to a move's type.@"
+	line "to a move's type.@"
 
 TriAttackDescription:
 	db   "Fires three kinds"
-	next "of beams at once.@"
+	line "of beams at once.@"
 
 SuperFangDescription:
 	db   "Cuts the foe's HP"
-	next "by 1/2.@"
+	line "by 1/2.@"
 
 SlashDescription:
 	db   "Has a high criti-"
-	next "cal hit ratio.@"
+	line "cal hit ratio.@"
 
 SubstituteDescription:
 	db   "Makes a decoy with"
-	next "1/4 user's max HP.@"
+	line "1/4 user's max HP.@"
 
 StruggleDescription:
 	db   "Used only if all"
-	next "PP are exhausted.@"
+	line "PP are exhausted.@"
 
 SketchDescription:
 	db   "Copies the foe's"
-	next "move permanently.@"
+	line "move permanently.@"
 
 TripleKickDescription:
 	db   "Hits three times"
-	next "with rising power.@"
+	line "with rising power.@"
 
 ThiefDescription:
 	db   "An attack that may"
-	next "steal a held item.@"
+	line "steal a held item.@"
 
 SpiderWebDescription:
 	db   "Prevents fleeing"
-	next "or switching.@"
+	line "or switching.@"
 
 MindReaderDescription:
 	db   "Ensures the next"
-	next "attack will hit.@"
+	line "attack will hit.@"
 
 NightmareDescription:
 	db   "A sleeper loses"
-	next "1/4 HP every turn.@"
+	line "1/4 HP every turn.@"
 
 FlameWheelDescription:
 	db   "An attack that may"
-	next "cause a burn.@"
+	line "cause a burn.@"
 
 SnoreDescription:
 	db   "An attack useable"
-	next "only while asleep.@"
+	line "only while asleep.@"
 
 CurseDescription:
 	db   "Works differently"
-	next "for ghost-types.@"
+	line "for ghost-types.@"
 
 FlailDescription:
 	db   "Stronger if the"
-	next "user's HP is low.@"
+	line "user's HP is low.@"
 
 Conversion2Description:
 	db   "The user's type is"
-	next "made resistant.@"
+	line "made resistant.@"
 
 AeroblastDescription:
 	db   "Has a high criti-"
-	next "cal hit ratio.@"
+	line "cal hit ratio.@"
 
 CottonSporeDescription:
 	db   "Sharply reduces"
-	next "the foe's SPEED.@"
+	line "the foe's SPEED.@"
 
 ReversalDescription:
 	db   "Stronger if the"
-	next "user's HP is low.@"
+	line "user's HP is low.@"
 
 SpiteDescription:
 	db   "Cuts the PP of the"
-	next "foe's last move.@"
+	line "foe's last move.@"
 
 PowderSnowDescription:
 	db   "An attack that may"
-	next "cause freezing.@"
+	line "cause freezing.@"
 
 ProtectDescription:
 	db   "Foils attack that"
-	next "turn. It may fail.@"
+	line "turn. It may fail.@"
 
 MachPunchDescription:
 	db   "A fast punch that"
-	next "lands first.@"
+	line "lands first.@"
 
 ScaryFaceDescription:
 	db   "Sharply reduces"
-	next "the foe's SPEED.@"
+	line "the foe's SPEED.@"
 
 FaintAttackDescription:
 	db   "An attack that"
-	next "never misses.@"
+	line "never misses.@"
 
 SweetKissDescription:
 	db   "A move that causes"
-	next "confusion.@"
+	line "confusion.@"
 
 BellyDrumDescription:
 	db   "Reduces own HP to"
-	next "maximize ATTACK.@"
+	line "maximize ATTACK.@"
 
 SludgeBombDescription:
 	db   "An attack that may"
-	next "poison the foe.@"
+	line "poison the foe.@"
 
 MudSlapDescription:
 	db   "Reduces the foe's"
-	next "accuracy.@"
+	line "accuracy.@"
 
 OctazookaDescription:
 	db   "An attack that may"
-	next "reduce accuracy.@"
+	line "reduce accuracy.@"
 
 SpikesDescription:
 	db   "Hurts foes when"
-	next "they switch out.@"
+	line "they switch out.@"
 
 ZapCannonDescription:
 	db   "An attack that"
-	next "always paralyzes.@"
+	line "always paralyzes.@"
 
 ForesightDescription:
 	db   "Negates accuracy"
-	next "reduction moves.@"
+	line "reduction moves.@"
 
 DestinyBondDescription:
 	db   "The foe faints if"
-	next "the user does.@"
+	line "the user does.@"
 
 PerishSongDescription:
 	db   "Both user and foe"
-	next "faint in 3 turns.@"
+	line "faint in 3 turns.@"
 
 IcyWindDescription:
 	db   "An icy attack that"
-	next "lowers SPEED.@"
+	line "lowers SPEED.@"
 
 DetectDescription:
 	db   "Evades attack that"
-	next "turn. It may fail.@"
+	line "turn. It may fail.@"
 
 BoneRushDescription:
 	db   "An attack that"
-	next "hits 2-5 times.@"
+	line "hits 2-5 times.@"
 
 LockOnDescription:
 	db   "Ensures the next"
-	next "attack will hit.@"
+	line "attack will hit.@"
 
 OutrageDescription:
 	db   "Works 2-3 turns"
-	next "and confuses user.@"
+	line "and confuses user.@"
 
 SandstormDescription:
 	db   "Inflicts damage"
-	next "every turn.@"
+	line "every turn.@"
 
 GigaDrainDescription:
 	db   "Steals 1/2 of the"
-	next "damage inflicted.@"
+	line "damage inflicted.@"
 
 EndureDescription:
 	db   "Always leaves at"
-	next "least 1HP.@"
+	line "least 1HP.@"
 
 CharmDescription:
 	db   "Sharply lowers the"
-	next "foe's ATTACK.@"
+	line "foe's ATTACK.@"
 
 RolloutDescription:
 	db   "Attacks 5 turns"
-	next "with rising power.@"
+	line "with rising power.@"
 
 FalseSwipeDescription:
 	db   "Leaves the foe"
-	next "with at least 1HP.@"
+	line "with at least 1HP.@"
 
 SwaggerDescription:
 	db   "Causes confusion"
-	next "and raises ATTACK.@"
+	line "and raises ATTACK.@"
 
 MilkDrinkDescription:
 	db   "Restores HP by 1/2"
-	next "the max HP.@"
+	line "the max HP.@"
 
 SparkDescription:
 	db   "An attack that may"
-	next "cause paralysis.@"
+	line "cause paralysis.@"
 
 FuryCutterDescription:
 	db   "Successive hits"
-	next "raise power.@"
+	line "raise power.@"
 
 SteelWingDescription:
 	db   "Stiff wings strike"
-	next "the foe.@"
+	line "the foe.@"
 
 MeanLookDescription:
 	db   "Prevents fleeing"
-	next "or switching.@"
+	line "or switching.@"
 
 AttractDescription:
 	db   "Makes the opposite"
-	next "gender infatuated.@"
+	line "gender infatuated.@"
 
 SleepTalkDescription:
 	db   "Randomly attacks"
-	next "while asleep.@"
+	line "while asleep.@"
 
 HealBellDescription:
 	db   "Eliminates all"
-	next "status problems.@"
+	line "status problems.@"
 
 ReturnDescription:
 	db   "An attack that is"
-	next "based on loyalty.@"
+	line "based on loyalty.@"
 
 PresentDescription:
 	db   "A bomb that may"
-	next "restore HP.@"
+	line "restore HP.@"
 
 FrustrationDescription:
 	db   "An attack based on"
-	next "lack of loyalty.@"
+	line "lack of loyalty.@"
 
 SafeguardDescription:
 	db   "Prevents all"
-	next "status problems.@"
+	line "status problems.@"
 
 PainSplitDescription:
 	db   "Adds user & foe's"
-	next "HPs. Shares total.@"
+	line "HPs. Shares total.@"
 
 SacredFireDescription:
 	db   "An attack that may"
-	next "inflict a burn.@"
+	line "inflict a burn.@"
 
 MagnitudeDescription:
 	db   "A ground attack"
-	next "with random power.@"
+	line "with random power.@"
 
 DynamicpunchDescription:
 	db   "An attack that"
-	next "always confuses.@"
+	line "always confuses.@"
 
 MegahornDescription:
 	db   "A powerful charge"
-	next "attack.@"
+	line "attack.@"
 
 DragonbreathDescription:
 	db   "A strong breath"
-	next "attack.@"
+	line "attack.@"
 
 BatonPassDescription:
 	db   "Switches while"
-	next "keeping effects.@"
+	line "keeping effects.@"
 
 EncoreDescription:
 	db   "Makes the foe re-"
-	next "peat 2-6 times.@"
+	line "peat 2-6 times.@"
 
 PursuitDescription:
 	db   "Heavily strikes"
-	next "switching #MON.@"
+	line "switching #MON.@"
 
 RapidSpinDescription:
 	db   "A high-speed"
-	next "spinning attack.@"
+	line "spinning attack.@"
 
 SweetScentDescription:
 	db   "Reduces the foe's"
-	next "evasiveness.@"
+	line "evasiveness.@"
 
 IronTailDescription:
 	db   "An attack that may"
-	next "reduce DEFENSE.@"
+	line "reduce DEFENSE.@"
 
 MetalClawDescription:
 	db   "An attack that may"
-	next "up user's ATTACK.@"
+	line "up user's ATTACK.@"
 
 VitalThrowDescription:
 	db   "A 2nd-strike move"
-	next "that never misses.@"
+	line "that never misses.@"
 
 MorningSunDescription:
 	db   "Restores HP"
-	next "(varies by time).@"
+	line "(varies by time).@"
 
 SynthesisDescription:
 	db   "Restores HP"
-	next "(varies by time).@"
+	line "(varies by time).@"
 
 MoonlightDescription:
 	db   "Restores HP"
-	next "(varies by time).@"
+	line "(varies by time).@"
 
 HiddenPowerDescription:
 	db   "The power varies"
-	next "with the #MON.@"
+	line "with the #MON.@"
 
 CrossChopDescription:
 	db   "Has a high criti-"
-	next "cal hit ratio.@"
+	line "cal hit ratio.@"
 
 TwisterDescription:
 	db   "Whips up a tornado"
-	next "to attack.@"
+	line "to attack.@"
 
 RainDanceDescription:
 	db   "Boosts water-type"
-	next "moves for 5 turns.@"
+	line "moves for 5 turns.@"
 
 SunnyDayDescription:
 	db   "Boosts fire-type"
-	next "moves for 5 turns.@"
+	line "moves for 5 turns.@"
 
 CrunchDescription:
 	db   "An attack that may"
-	next "lower SPCL.DEF.@"
+	line "lower SPCL.DEF.@"
 
 MirrorCoatDescription:
 	db   "Counters a SPCL."
-	next "ATK move double.@"
+	line "ATK move double.@"
 
 PsychUpDescription:
 	db   "Copies the foe's"
-	next "stat changes.@"
+	line "stat changes.@"
 
 ExtremespeedDescription:
 	db   "A powerful first-"
-	next "strike move.@"
+	line "strike move.@"
 
 AncientpowerDescription:
 	db   "An attack that may"
-	next "raise all stats.@"
+	line "raise all stats.@"
 
 ShadowBallDescription:
 	db   "An attack that may"
-	next "lower SPCL.DEF.@"
+	line "lower SPCL.DEF.@"
 
 FutureSightDescription:
 	db   "An attack that"
-	next "hits on 3rd turn.@"
+	line "hits on 3rd turn.@"
 
 RockSmashDescription:
 	db   "An attack that may"
-	next "lower DEFENSE.@"
+	line "lower DEFENSE.@"
 
 WhirlpoolDescription:
 	db   "Traps the foe for"
-	next "2-5 turns.@"
+	line "2-5 turns.@"
 
 BeatUpDescription:
 	db   "Party #MON join"
-	next "in the attack.@"
+	line "in the attack.@"

--- a/data/text/battle.asm
+++ b/data/text/battle.asm
@@ -689,6 +689,16 @@ AlreadyAsleepText:
 	line "already asleep!"
 	prompt
 
+AlreadyBurnedText:
+	text "<TARGET>'s"
+	line "already burned!"
+	prompt
+
+AlreadyFrozenText:
+	text "<TARGET>'s"
+	line "already frozen!"
+	prompt
+
 WasPoisonedText:
 	text "<TARGET>"
 	line "was poisoned!"

--- a/engine/battle/effect_commands.asm
+++ b/engine/battle/effect_commands.asm
@@ -3647,6 +3647,32 @@ UpdateMoveData:
 	call GetMoveName
 	jp CopyName1
 
+CheckForStatusIfAlreadyHasAny:
+	ld a, BATTLE_VARS_STATUS_OPP
+	call GetBattleVarAddr
+	ld d, h
+	ld e, l
+	and SLP_MASK
+	ld hl, AlreadyAsleepText
+	ret nz
+	
+	ld a, [de]
+	bit FRZ, a
+	ld hl, AlreadyFrozenText
+	ret nz
+	
+	bit PAR, a
+	ld hl, AlreadyParalyzedText
+	ret nz
+	
+	bit PSN, a
+	ld hl, AlreadyPoisonedText
+	ret nz
+	
+	bit BRN, a
+	ld hl, AlreadyBurnedText
+	ret
+
 BattleCommand_SleepTarget:
 	call GetOpponentItem
 	ld a, b
@@ -3660,13 +3686,7 @@ BattleCommand_SleepTarget:
 	jr .fail
 
 .not_protected_by_item
-	ld a, BATTLE_VARS_STATUS_OPP
-	call GetBattleVarAddr
-	ld d, h
-	ld e, l
-	ld a, [de]
-	and SLP_MASK
-	ld hl, AlreadyAsleepText
+	call CheckForStatusIfAlreadyHasAny
 	jr nz, .fail
 
 	ld a, [wAttackMissed]
@@ -3676,10 +3696,6 @@ BattleCommand_SleepTarget:
 	ld hl, DidntAffect1Text
 	call .CheckAIRandomFail
 	jr c, .fail
-
-	ld a, [de]
-	and a
-	jr nz, .fail
 
 	call CheckSubstituteOpp
 	jr nz, .fail
@@ -3786,11 +3802,7 @@ BattleCommand_Poison:
 	call CheckIfTargetIsPoisonType
 	jp z, .failed
 
-	ld a, BATTLE_VARS_STATUS_OPP
-	call GetBattleVar
-	ld b, a
-	ld hl, AlreadyPoisonedText
-	and 1 << PSN
+	call CheckForStatusIfAlreadyHasAny
 	jp nz, .failed
 
 	call GetOpponentItem
@@ -3831,8 +3843,11 @@ BattleCommand_Poison:
 	jr c, .failed
 
 .dont_sample_failure
+	ld hl, ProtectingItselfText
 	call CheckSubstituteOpp
 	jr nz, .failed
+
+	ld hl, EvadedText
 	ld a, [wAttackMissed]
 	and a
 	jr nz, .failed
@@ -5920,9 +5935,7 @@ BattleCommand_Confuse_CheckSnore_Swagger_ConfuseHit:
 	jp PrintDidntAffect2
 
 BattleCommand_Paralyze:
-	ld a, BATTLE_VARS_STATUS_OPP
-	call GetBattleVar
-	bit PAR, a
+	call CheckForStatusIfAlreadyHasAny
 	jr nz, .paralyzed
 	ld a, [wTypeModifier]
 	and EFFECTIVENESS_MASK
@@ -5960,10 +5973,6 @@ BattleCommand_Paralyze:
 	jr c, .failed
 
 .dont_sample_failure
-	ld a, BATTLE_VARS_STATUS_OPP
-	call GetBattleVarAddr
-	and a
-	jr nz, .failed
 	ld a, [wAttackMissed]
 	and a
 	jr nz, .failed
@@ -5986,8 +5995,9 @@ BattleCommand_Paralyze:
 	jp CallBattleCore
 
 .paralyzed
+	push hl
 	call AnimateFailedMove
-	ld hl, AlreadyParalyzedText
+	pop hl
 	jp StdBattleTextbox
 
 .failed
@@ -6314,8 +6324,8 @@ PrintDidntAffect:
 
 PrintDidntAffect2:
 	call AnimateFailedMove
-	ld hl, DidntAffect1Text ; 'it didn't affect'
-	ld de, DidntAffect2Text ; 'it didn't affect'
+	ld hl, EvadedText ; 'evaded the attack'
+	ld de, ProtectingItselfText ; 'protecting itself'
 	jp FailText_CheckOpponentProtect
 
 PrintParalyze:

--- a/engine/battle/effect_commands.asm
+++ b/engine/battle/effect_commands.asm
@@ -3770,7 +3770,11 @@ BattleCommand_PoisonTarget:
 	ld a, [wTypeModifier]
 	and EFFECTIVENESS_MASK
 	ret z
-	call CheckIfTargetIsPoisonType
+	ld b, POISON ; Don't poison a Poison-type
+	call CheckIfTargetIsGivenType
+	ret z
+	ld b, STEEL ; Don't poison a Steel-type
+	call CheckIfTargetIsGivenType
 	ret z
 	call GetOpponentItem
 	ld a, b
@@ -3799,7 +3803,12 @@ BattleCommand_Poison:
 	and EFFECTIVENESS_MASK
 	jp z, .failed
 
-	call CheckIfTargetIsPoisonType
+	ld b, POISON
+	call CheckIfTargetIsGivenType
+	jp z, .failed
+
+	ld b, STEEL
+	call CheckIfTargetIsGivenType
 	jp z, .failed
 
 	call CheckForStatusIfAlreadyHasAny
@@ -3897,7 +3906,7 @@ BattleCommand_Poison:
 	cp EFFECT_TOXIC
 	ret
 
-CheckIfTargetIsPoisonType:
+CheckIfTargetIsGivenType:
 	ld de, wEnemyMonType1
 	ldh a, [hBattleTurn]
 	and a
@@ -3906,10 +3915,10 @@ CheckIfTargetIsPoisonType:
 .ok
 	ld a, [de]
 	inc de
-	cp POISON
+	cp b
 	ret z
 	ld a, [de]
-	cp POISON
+	cp b
 	ret
 
 PoisonOpponent:
@@ -4033,7 +4042,8 @@ BattleCommand_BurnTarget:
 	ld a, [wTypeModifier]
 	and EFFECTIVENESS_MASK
 	ret z
-	call CheckMoveTypeMatchesTarget ; Don't burn a Fire-type
+	ld b, FIRE ; Don't burn a Fire-type
+	call CheckIfTargetIsGivenType
 	ret z
 	call GetOpponentItem
 	ld a, b
@@ -4100,7 +4110,8 @@ BattleCommand_FreezeTarget:
 	ld a, [wBattleWeather]
 	cp WEATHER_SUN
 	ret z
-	call CheckMoveTypeMatchesTarget ; Don't freeze an Ice-type
+	ld b, ICE ; Don't freeze an Ice-type
+	call CheckIfTargetIsGivenType
 	ret z
 	call GetOpponentItem
 	ld a, b
@@ -6006,42 +6017,6 @@ BattleCommand_Paralyze:
 .didnt_affect
 	call AnimateFailedMove
 	jp PrintDoesntAffect
-
-CheckMoveTypeMatchesTarget:
-; Compare move type to opponent type.
-; Return z if matching the opponent type,
-; unless the move is Normal (Tri Attack).
-
-	push hl
-
-	ld hl, wEnemyMonType1
-	ldh a, [hBattleTurn]
-	and a
-	jr z, .ok
-	ld hl, wBattleMonType1
-.ok
-
-	ld a, BATTLE_VARS_MOVE_TYPE
-	call GetBattleVar
-	and TYPE_MASK
-	cp NORMAL
-	jr z, .normal
-
-	cp [hl]
-	jr z, .return
-
-	inc hl
-	cp [hl]
-
-.return
-	pop hl
-	ret
-
-.normal
-	ld a, 1
-	and a
-	pop hl
-	ret
 
 INCLUDE "engine/battle/move_effects/substitute.asm"
 

--- a/engine/battle/effect_commands.asm
+++ b/engine/battle/effect_commands.asm
@@ -3694,8 +3694,6 @@ BattleCommand_SleepTarget:
 	jp nz, PrintDidntAffect2
 
 	ld hl, DidntAffect1Text
-	call .CheckAIRandomFail
-	jr c, .fail
 
 	call CheckSubstituteOpp
 	jr nz, .fail
@@ -3731,34 +3729,6 @@ BattleCommand_SleepTarget:
 	call AnimateFailedMove
 	pop hl
 	jp StdBattleTextbox
-
-.CheckAIRandomFail:
-	; Enemy turn
-	ldh a, [hBattleTurn]
-	and a
-	jr z, .dont_fail
-
-	; Not in link battle
-	ld a, [wLinkMode]
-	and a
-	jr nz, .dont_fail
-
-	ld a, [wInBattleTowerBattle]
-	and a
-	jr nz, .dont_fail
-
-	; Not locked-on by the enemy
-	ld a, [wPlayerSubStatus5]
-	bit SUBSTATUS_LOCK_ON, a
-	jr nz, .dont_fail
-
-	call BattleRandom
-	cp 25 percent + 1 ; 25% chance AI fails
-	ret c
-
-.dont_fail
-	xor a
-	ret
 
 BattleCommand_PoisonTarget:
 	call CheckSubstituteOpp
@@ -3831,27 +3801,6 @@ BattleCommand_Poison:
 	and a
 	jr nz, .failed
 
-	ldh a, [hBattleTurn]
-	and a
-	jr z, .dont_sample_failure
-
-	ld a, [wLinkMode]
-	and a
-	jr nz, .dont_sample_failure
-
-	ld a, [wInBattleTowerBattle]
-	and a
-	jr nz, .dont_sample_failure
-
-	ld a, [wPlayerSubStatus5]
-	bit SUBSTATUS_LOCK_ON, a
-	jr nz, .dont_sample_failure
-
-	call BattleRandom
-	cp 25 percent + 1 ; 25% chance AI fails
-	jr c, .failed
-
-.dont_sample_failure
 	ld hl, ProtectingItselfText
 	call CheckSubstituteOpp
 	jr nz, .failed
@@ -4449,41 +4398,12 @@ BattleCommand_StatDown:
 ; Sharply lower the stat if applicable.
 	ld a, [wLoweredStat]
 	and $f0
-	jr z, .ComputerMiss
+	jr z, .GotAmountToLower
 	dec b
-	jr nz, .ComputerMiss
+	jr z, .GotAmountToLower
 	inc b
 
-.ComputerMiss:
-; Computer opponents have a 25% chance of failing.
-	ldh a, [hBattleTurn]
-	and a
-	jr z, .DidntMiss
-
-	ld a, [wLinkMode]
-	and a
-	jr nz, .DidntMiss
-
-	ld a, [wInBattleTowerBattle]
-	and a
-	jr nz, .DidntMiss
-
-; Lock-On still always works.
-	ld a, [wPlayerSubStatus5]
-	bit SUBSTATUS_LOCK_ON, a
-	jr nz, .DidntMiss
-
-; Attacking moves that also lower accuracy are unaffected.
-	ld a, BATTLE_VARS_MOVE_EFFECT
-	call GetBattleVar
-	cp EFFECT_ACCURACY_DOWN_HIT
-	jr z, .DidntMiss
-
-	call BattleRandom
-	cp 25 percent + 1 ; 25% chance AI fails
-	jr c, .Failed
-
-.DidntMiss:
+.GotAmountToLower:
 	call CheckSubstituteOpp
 	jr nz, .Failed
 
@@ -5963,27 +5883,6 @@ BattleCommand_Paralyze:
 	jp StdBattleTextbox
 
 .no_item_protection
-	ldh a, [hBattleTurn]
-	and a
-	jr z, .dont_sample_failure
-
-	ld a, [wLinkMode]
-	and a
-	jr nz, .dont_sample_failure
-
-	ld a, [wInBattleTowerBattle]
-	and a
-	jr nz, .dont_sample_failure
-
-	ld a, [wPlayerSubStatus5]
-	bit SUBSTATUS_LOCK_ON, a
-	jr nz, .dont_sample_failure
-
-	call BattleRandom
-	cp 25 percent + 1 ; 25% chance AI fails
-	jr c, .failed
-
-.dont_sample_failure
 	ld a, [wAttackMissed]
 	and a
 	jr nz, .failed

--- a/engine/pokemon/mon_menu.asm
+++ b/engine/pokemon/mon_menu.asm
@@ -984,10 +984,13 @@ MoveScreenLoop:
 	hlcoord 1, 11
 	ld bc, 8
 	call ByteFill
+	hlcoord 1, 11
+	lb bc, 5, 7
+	call ClearBox
 	hlcoord 1, 12
 	lb bc, 5, SCREEN_WIDTH - 2
 	call ClearBox
-	hlcoord 1, 12
+	hlcoord 2, 13
 	ld de, String_MoveWhere
 	call PlaceString
 	jp .joy_loop
@@ -1020,6 +1023,8 @@ MoveScreenLoop:
 	ld a, [wCurPartyMon]
 	cp b
 	jp z, .joy_loop
+	ld de, SFX_SWITCH_POCKETS
+	call PlaySFX
 	jp MoveScreenLoop
 
 .d_left
@@ -1034,6 +1039,8 @@ MoveScreenLoop:
 	ld a, [wCurPartyMon]
 	cp b
 	jp z, .joy_loop
+	ld de, SFX_SWITCH_POCKETS
+	call PlaySFX
 	jp MoveScreenLoop
 
 .cycle_right
@@ -1160,7 +1167,7 @@ MoveScreen2DMenuData:
 	db D_UP | D_DOWN | D_LEFT | D_RIGHT | A_BUTTON | B_BUTTON ; accepted buttons
 
 String_MoveWhere:
-	db "Where?@"
+	db "Select a move<NEXT>to swap places.@"
 
 SetUpMoveScreenBG:
 	call ClearBGPalettes
@@ -1179,8 +1186,8 @@ SetUpMoveScreenBG:
 	ld [wTempIconSpecies], a
 	ld e, MONICON_MOVES
 	farcall LoadMenuMonIcon
-	hlcoord 0, 1
-	ld b, 9
+	hlcoord 0, -1
+	ld b, 1
 	ld c, 18
 	call Textbox
 	hlcoord 0, 11
@@ -1254,34 +1261,79 @@ PrepareToPlaceMoveData:
 PlaceMoveData:
 	xor a
 	ldh [hBGMapMode], a
+
+; Print UI elements
 	hlcoord 0, 10
 	ld de, String_MoveType_Top
 	call PlaceString
 	hlcoord 0, 11
 	ld de, String_MoveType_Bottom
 	call PlaceString
-	hlcoord 12, 12
+	hlcoord 1, 11
 	ld de, String_MoveAtk
 	call PlaceString
+	hlcoord 1, 12
+	ld de, String_MoveAcc
+	call PlaceString
+	hlcoord 1, 13
+	ld de, String_MoveEff
+	call PlaceString
+
+; Print move effect chance
+	ld a, [wCurSpecies]
+	ld l, a
+	ld a, MOVE_CHANCE
+	call GetMoveAttribute
+	cp 1
+	jr c, .if_null_chance
+	call ConvertPercentages
+	hlcoord 5, 13
+	ld [wBuffer1], a
+	ld de, wBuffer1
+	lb bc, 1, 3
+	call PrintNum
+	jr .skip_null_chance
+
+.if_null_chance
+	ld de, String_MoveNoPower
+	ld bc, 3
+	hlcoord 5, 13
+	call PlaceString
+
+.skip_null_chance
+
+; Print move accuracy
+	ld a, [wCurSpecies]
+	ld l, a
+	ld a, MOVE_ACC
+	call GetMoveAttribute
+	call ConvertPercentages
+	ld [wBuffer1], a
+	ld de, wBuffer1
+	lb bc, 1, 3
+	hlcoord 5, 12
+	call PrintNum
+
+; Print move type
 	ld a, [wCurSpecies]
 	ld b, a
-
 	farcall GetMoveCategoryName
-	hlcoord 1, 11
+	hlcoord 10, 12
 	ld de, wStringBuffer1
 	call PlaceString
 	ld a, [wCurSpecies]
 	ld b, a
-	hlcoord 1, 12
+	hlcoord 10, 13
 	ld [hl], "/"
 	inc hl
-
 	predef PrintMoveType
+
+; Print move power
 	ld a, [wCurSpecies]
 	ld l, a
 	ld a, MOVE_POWER
 	call GetMoveAttribute
-	hlcoord 16, 12
+	hlcoord 5, 11
 	cp 2
 	jr c, .no_power
 	ld [wTextDecimalByte], a
@@ -1294,19 +1346,74 @@ PlaceMoveData:
 	ld de, String_MoveNoPower
 	call PlaceString
 
+; Print move description
 .description
-	hlcoord 1, 14
+	hlcoord 1, 15
 	predef PrintMoveDescription
 	ld a, $1
 	ldh [hBGMapMode], a
 	ret
 
+; This converts values out of 256 into a value
+; out of 100. It achieves this by multiplying
+; the value by 100 and dividing it by 256.
+ConvertPercentages:
+
+	; Overwrite the "hl" register.
+	ld l, a
+	ld h, 0
+	push af
+
+	; Multiplies the value of the "hl" register by 3.
+	add hl, hl
+	add a, l
+	ld l, a
+	adc h
+	sub l
+	ld h, a
+
+	; Multiplies the value of the "hl" register
+	; by 8. The value of the "hl" register
+	; is now 24 times its original value.
+	add hl, hl
+	add hl, hl
+	add hl, hl
+
+	; Add the original value of the "hl" value to itself,
+	; making it 25 times its original value.
+	pop af
+	add a, l
+	ld l, a
+	adc h
+	sbc l
+	ld h, a
+
+	; Multiply the value of the "hl" register by
+	; 4, making it 100 times its original value.
+	add hl, hl
+	add hl, hl
+
+	; Set the "l" register to 0.5, otherwise the rounded
+	; value may be lower than expected. Round the
+	; high byte to nearest and drop the low byte.
+	ld l, 0.5
+	sla l
+	sbc a
+	and 1
+	add a, h
+	ret
+
+; UI elements
 String_MoveType_Top:
 	db "┌────────┐@"
 String_MoveType_Bottom:
 	db "│        └@"
 String_MoveAtk:
-	db "ATK/@"
+	db "PWR/@"
+String_MoveAcc:
+	db "ACC/@"
+String_MoveEff:
+	db "EFF/@"
 String_MoveNoPower:
 	db "---@"
 

--- a/ram/wram.asm
+++ b/ram/wram.asm
@@ -2312,7 +2312,7 @@ wStringBuffer5:: ds STRING_BUFFER_LENGTH
 
 wBattleMenuCursorPosition:: db
 
-	ds 1
+wBuffer1:: db
 
 wCurBattleMon::
 ; index of the player's mon currently in battle (0-5)


### PR DESCRIPTION
Add improved move screen with more information, and the following:

- Distinguish between move miss and fail in battle
- Prevent Steel-types from being poisoned with Twineedle (and fire and ice burns/freezes with tri-attack)
- Remove 25% failure chance for AI status moves

Closes #30 