### PR TITLE
allow hmfield move usage if mon can learn a the move

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -42,3 +42,4 @@ The following keeps track of specific credits for assets and features.
 - [Make new battle text to distinguish status move misses and fails](https://github.com/pret/pokecrystal/wiki/Make-new-battle-text-to-distinguish-status-move-misses-and-fails)
 - [Prevent Steel‐types from being poisoned by Twineedle](https://github.com/pret/pokecrystal/wiki/Prevent-Steel%E2%80%90types-from-being-poisoned-by-Twineedle)
 - [Remove the 25% failure chance for AI status moves](https://github.com/pret/pokecrystal/wiki/Remove-the-25%25-failure-chance-for-AI-status-moves)
+- [Allow using a field move if the Pokemon can learn it](https://github.com/pret/pokecrystal/wiki/Allow-Using-a-Field-Move-if-the-Pokemon-Can-Learn-It#1-adding-the-new-canpartylearnmove-function-well-be-using)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -36,7 +36,7 @@ This document is a living checklist outlining the items needed to be complete pr
 - [x] Fast Pokemon Center healing
 - [x] Remove Pokemon fleeing
 - [x] Fix trainer card leader heads
-- [ ] Field moves/Revisit HM usage
+- [x] Field moves/Revisit HM usage
 - [x] Increase shiny odds to 1/4096
 - [x] Dynamic battle palette
 - [x] Nayru's PokeDex

--- a/engine/events/overworld.asm
+++ b/engine/events/overworld.asm
@@ -109,6 +109,93 @@ CheckPartyMove:
 	scf
 	ret
 
+CheckPartyCanLearnMoveIndex:
+; Check if a monster in your party has move hl.
+	call GetMoveIDFromIndex
+	ld d, a
+CheckPartyCanLearnMove:
+; CHECK IF MONSTER IN PARTY CAN LEARN MOVE D
+	ld e, 0
+	xor a
+	ld [wCurPartyMon], a
+.loop
+	ld c, e
+	ld b, 0
+	ld hl, wPartySpecies
+	add hl, bc
+	ld a, [hl]
+	and a
+	jr z, .no
+	cp -1
+	jr z, .no
+	cp EGG
+	jr z, .next
+
+	ld [wCurPartySpecies], a
+	ld a, d
+; Check the TM/HM/Move Tutor list
+	ld [wPutativeTMHMMove], a
+	push de
+	farcall CanLearnTMHMMove
+	pop de
+.check
+	ld a, c
+	and a
+	jr nz, .yes
+; Check the Pokemon's Level-Up Learnset
+	ld b,b
+	ld a, d
+	push de
+	call OW_CheckLvlUpMoves
+	pop de
+	jr nc, .yes
+; done checking
+
+.next
+	inc e
+	jr .loop
+
+.yes
+	ld a, e
+	; which mon can learn the move
+	ld [wCurPartyMon], a
+	xor a
+	ret
+.no
+	ld a, 1
+	ret
+
+OW_CheckLvlUpMoves:
+	ld d, a
+	ld a, [wTempSpecies]
+	call GetPokemonIndexFromID
+	ld b, h
+	ld c, l
+	ld hl, EvosAttacksPointers
+	ld a, BANK(EvosAttacksPointers)
+	call LoadDoubleIndirectPointer
+	ld [wStatsScreenFlags], a ; bank
+	call FarSkipEvolutions
+.learnset_loop
+	call GetFarByte
+  	and a
+	jr z, .notfound
+	inc hl
+	call GetFarWord
+	call GetMoveIDFromIndex
+	cp d
+	jr z, .found
+	inc hl
+	inc hl
+	jr .learnset_loop
+
+.found
+	xor a
+	ret ; move is in lvl up learnset
+.notfound
+	scf ; move isnt in lvl up learnset
+	ret
+
 FieldMoveFailed:
 	ld hl, .CantUseItemText
 	call MenuTextboxBackup
@@ -506,14 +593,29 @@ TrySurfOW::
 	call CheckDirection
 	jr c, .quit
 
+; Step 1
 	ld de, ENGINE_FOGBADGE
 	call CheckEngineFlag
 	jr c, .quit
 
+; Step 2
+	ld a, HM_SURF
+	ld [wCurItem], a
+	ld hl, wNumItems
+	call CheckItem
+	jr z, .quit
+
+; Step 3
+ 	ld hl, SURF
+	call CheckPartyCanLearnMoveIndex
+	and a
+	jr z, .yes
+
+; Step 4
 	ld hl, SURF
 	call CheckPartyMoveIndex
 	jr c, .quit
-
+.yes
 	ld hl, wBikeFlags
 	bit BIKEFLAGS_ALWAYS_ON_BIKE_F, [hl]
 	jr nz, .quit
@@ -709,12 +811,28 @@ Script_UsedWaterfall:
 	text_end
 
 TryWaterfallOW::
-	ld hl, WATERFALL
-	call CheckPartyMoveIndex
-	jr c, .failed
+; Step 1
 	ld de, ENGINE_RISINGBADGE
 	call CheckEngineFlag
 	jr c, .failed
+; Step 2
+	ld a, HM_WATERFALL
+	ld [wCurItem], a
+	ld hl, wNumItems
+	call CheckItem
+	jr z, .failed
+
+; Step 3
+	ld hl, WATERFALL
+	call CheckPartyCanLearnMoveIndex
+	and a
+	jr z, .yes
+
+; Step 4
+	ld hl, WATERFALL
+	call CheckPartyMoveIndex
+	jr c, .failed
+.yes
 	call CheckMapCanWaterfall
 	jr c, .failed
 	ld a, BANK(Script_AskWaterfall)
@@ -1060,14 +1178,30 @@ BouldersMayMoveText:
 	text_end
 
 TryStrengthOW:
-	ld hl, STRENGTH
-	call CheckPartyMoveIndex
-	jr c, .nope
-
+; Step 1
 	ld de, ENGINE_PLAINBADGE
 	call CheckEngineFlag
 	jr c, .nope
 
+; Step 2
+	ld a, HM_STRENGTH
+	ld [wCurItem], a
+	ld hl, wNumItems
+	call CheckItem
+	jr z, .nope
+
+; Step 3
+	ld d, STRENGTH
+	call CheckPartyCanLearnMove
+	and a
+	jr z, .yes
+
+; Step 4
+	ld d, STRENGTH
+	call CheckPartyMove
+	jr c, .nope
+
+.yes
 	ld hl, wBikeFlags
 	bit BIKEFLAGS_STRENGTH_ACTIVE_F, [hl]
 	jr z, .already_using
@@ -1194,12 +1328,33 @@ DisappearWhirlpool:
 	ret
 
 TryWhirlpoolOW::
+; Step 1
+	ld de, ENGINE_GLACIERBADGE
+	ld b, CHECK_FLAG
+	farcall EngineFlagAction
+	ld a, c
+	and a
+	jr z, .failed  ; .fail, dont have needed badge
+
+; Step 2
+	ld a, HM_WHIRLPOOL
+	ld [wCurItem], a
+	ld hl, wNumItems
+	call CheckItem
+	jr z, .failed
+
+; Step 3
+	ld hl, WHIRLPOOL
+	call CheckPartyCanLearnMoveIndex
+    and a
+	jr z, .yes
+
+; Step 4
 	ld hl, WHIRLPOOL
 	call CheckPartyMoveIndex
 	jr c, .failed
-	ld de, ENGINE_GLACIERBADGE
-	call CheckEngineFlag
-	jr c, .failed
+
+.yes
 	call TryWhirlpoolMenu
 	jr c, .failed
 	ld a, BANK(Script_AskWhirlpoolOW)
@@ -1289,10 +1444,24 @@ HeadbuttScript:
 	end
 
 TryHeadbuttOW::
+; Step 1
+	ld a, TM_HEADBUTT
+	ld [wCurItem], a
+	ld hl, wNumItems
+	call CheckItem
+	jr z, .no
+
+; Step 2
+	ld hl, HEADBUTT
+	call CheckPartyCanLearnMoveIndex
+    and a
+	jr z, .can_use ; cannot learn headbutt
+
+; Step 3
 	ld hl, HEADBUTT
 	call CheckPartyMoveIndex
 	jr c, .no
-
+.can_use
 	ld a, BANK(AskHeadbuttScript)
 	ld hl, AskHeadbuttScript
 	call CallScript
@@ -1413,10 +1582,24 @@ AskRockSmashText:
 	text_end
 
 HasRockSmash:
+; Step 1
+	ld a, TM_ROCK_SMASH
+	ld [wCurItem], a
+	ld hl, wNumItems
+	call CheckItem
+	jr z, .no
+
+; Step 2
+	ld hl, ROCK_SMASH
+	call CheckPartyCanLearnMoveIndex
+    and a
+	jr z, .yes
+
+; Step 3
 	ld hl, ROCK_SMASH
 	call CheckPartyMoveIndex
 	jr nc, .yes
-; no
+.no
 	ld a, 1
 	jr .done
 .yes
@@ -1765,14 +1948,29 @@ GotOffBikeText:
 	text_end
 
 TryCutOW::
-	ld hl, CUT
-	call CheckPartyMoveIndex
-	jr c, .cant_cut
-
+; Step 1
 	ld de, ENGINE_HIVEBADGE
 	call CheckEngineFlag
 	jr c, .cant_cut
 
+; Step 2
+	ld a, HM_CUT
+	ld [wCurItem], a
+	ld hl, wNumItems
+	call CheckItem
+	jr z, .cant_cut
+
+; Step 3
+	ld hl, CUT
+	call CheckPartyCanLearnMoveIndex
+    and a
+	jr z, .yes
+
+;Step 4
+	ld hl, CUT
+	call CheckPartyMoveIndex
+	jr c, .cant_cut
+.yes
 	ld a, BANK(AskCutScript)
 	ld hl, AskCutScript
 	call CallScript

--- a/engine/pc/bills_pc_ui.asm
+++ b/engine/pc/bills_pc_ui.asm
@@ -2762,8 +2762,7 @@ BillsPC_ReleaseAll:
 
 .NothingReleased:
 	text "You can't release"
-	line "EGGs or #MON"
-	cont "with HM moves."
+	line "EGGs."
 	prompt
 
 .ReleasedXMon:
@@ -2774,8 +2773,7 @@ BillsPC_ReleaseAll:
 	prompt
 
 .TheRestWasnt:
-	text "The rest are EGGs"
-	line "or know HM moves."
+	text "The rest are EGGs."
 	prompt
 
 BillsPC_Release:

--- a/engine/pokemon/mon_submenu.asm
+++ b/engine/pokemon/mon_submenu.asm
@@ -345,12 +345,12 @@ Sub_CheckLvlUpMoves:
 
 CanUseFlash:
 ; Step 1: Badge Check
-;	ld de, ENGINE_ZEPHYRBADGE
-;	ld b, CHECK_FLAG
-;	farcall EngineFlagAction
-;	ld a, c
-;	and a
-;	ret z ; .fail, dont have needed badge
+	ld de, ENGINE_ZEPHYRBADGE
+	ld b, CHECK_FLAG
+	farcall EngineFlagAction
+	ld a, c
+	and a
+	ret z ; .fail, dont have needed badge
 
 ; Step 2: Location Check
 	farcall SpecialAerodactylChamber
@@ -393,12 +393,12 @@ CanUseFlash:
 
 CanUseFly:
 ; Step 1: Badge Check
-;	ld de, ENGINE_STORMBADGE
-;	ld b, CHECK_FLAG
-;	farcall EngineFlagAction
-;	ld a, c
-;	and a
-;	ret z ; .fail, dont have needed badge
+	ld de, ENGINE_STORMBADGE
+	ld b, CHECK_FLAG
+	farcall EngineFlagAction
+	ld a, c
+	and a
+	ret z ; .fail, dont have needed badge
 
 ; Step 2: Location Check
 	call GetMapEnvironment

--- a/engine/pokemon/mon_submenu.asm
+++ b/engine/pokemon/mon_submenu.asm
@@ -383,7 +383,7 @@ CanUseFlash:
 	ld hl, FLASH
 	call GetMoveIDFromIndex
 	call Sub_CheckLvlUpMoves
-	;scf
+	scf
 	ret c ; fail
 
 .yes
@@ -429,7 +429,7 @@ CanUseFly:
 	ld hl, FLY
 	call GetMoveIDFromIndex
 	call Sub_CheckLvlUpMoves
-	;scf
+	scf
 	ret c ; fail
 .yes
 	ld a, MONMENUITEM_FLY
@@ -470,7 +470,7 @@ Can_Use_Sweet_Scent:
 	ld hl, SWEET_SCENT
 	call GetMoveIDFromIndex
 	call Sub_CheckLvlUpMoves
-	;scf
+	scf
 	ret c ; fail
 .yes
 	ld a, MONMENUITEM_SWEETSCENT
@@ -510,7 +510,7 @@ CanUseDig:
 	ld hl, DIG
 	call GetMoveIDFromIndex
 	call Sub_CheckLvlUpMoves
-	;scf
+	scf
 	ret c ; fail
 .yes
 	ld a, MONMENUITEM_DIG

--- a/engine/pokemon/mon_submenu.asm
+++ b/engine/pokemon/mon_submenu.asm
@@ -382,7 +382,7 @@ CanUseFlash:
 ; Step 6: Check if Mon can learn move from LVL-UP
 	ld hl, FLASH
 	call GetMoveIDFromIndex
-	call Sub_CheckLvlUpMoves
+	;call Sub_CheckLvlUpMoves
 	scf
 	ret c ; fail
 
@@ -428,7 +428,7 @@ CanUseFly:
 ; Step 6: Check if Mon can learn move via LVL-UP
 	ld hl, FLY
 	call GetMoveIDFromIndex
-	call Sub_CheckLvlUpMoves
+	;call Sub_CheckLvlUpMoves
 	scf
 	ret c ; fail
 .yes
@@ -469,7 +469,7 @@ Can_Use_Sweet_Scent:
 ; Step 5: Check if mon can learn move via LVL-UP
 	ld hl, SWEET_SCENT
 	call GetMoveIDFromIndex
-	call Sub_CheckLvlUpMoves
+	;call Sub_CheckLvlUpMoves
 	scf
 	ret c ; fail
 .yes
@@ -509,7 +509,7 @@ CanUseDig:
 ; Step 5: Check if Mon can learn move via LVL-UP
 	ld hl, DIG
 	call GetMoveIDFromIndex
-	call Sub_CheckLvlUpMoves
+	;call Sub_CheckLvlUpMoves
 	scf
 	ret c ; fail
 .yes

--- a/engine/pokemon/mon_submenu.asm
+++ b/engine/pokemon/mon_submenu.asm
@@ -120,29 +120,14 @@ GetMonSubmenuItems:
 	ld a, [wLinkMode]
 	and a
 	jr nz, .skip_moves
-	ld a, MON_MOVES
-	call GetPartyParamLocation
-	ld d, h
-	ld e, l
-	ld c, NUM_MOVES
-.loop
-	push bc
-	push de
-	ld a, [de]
-	and a
-	jr z, .next
-	push hl
-	call IsFieldMove
-	pop hl
-	jr nc, .next
-	call AddMonMenuItem
 
-.next
-	pop de
-	inc de
-	pop bc
-	dec c
-	jr nz, .loop
+	call CanUseFlash
+	call CanUseFly
+	call CanUseDig
+	call Can_Use_Sweet_Scent
+	call CanUseTeleport
+	call CanUseSoftboiled
+	call CanUseMilkdrink
 
 .skip_moves
 	ld a, MONMENUITEM_STATS
@@ -289,3 +274,283 @@ BattleMonMenu:
 	db "SWITCH@"
 	db "STATS@"
 	db "CANCEL@"
+
+CheckMonCanLearn_TM_HM:
+; Check if wCurPartySpecies can learn move in 'a'
+	ld [wPutativeTMHMMove], a
+	ld a, [wCurPartySpecies]
+	farcall CanLearnTMHMMove
+.check
+	ld a, c
+	and a
+	ret z
+; yes
+	scf
+	ret
+
+CheckMonKnowsMove:
+	ld b, a
+	ld a, MON_MOVES
+	call GetPartyParamLocation
+	ld d, h
+	ld e, l
+	ld c, NUM_MOVES
+.loop
+	ld a, [de]
+	and a
+	jr z, .next
+	cp b
+	jr z, .found ; knows move
+.next
+	inc de
+	dec c
+	jr nz, .loop
+	ld a, -1
+	scf ; mon doesnt know move
+	ret
+.found
+	xor a
+	ret z
+
+Sub_CheckLvlUpMoves:
+	ld d, a
+	ld a, [wTempSpecies]
+	call GetPokemonIndexFromID
+	ld b, h
+	ld c, l
+	ld hl, EvosAttacksPointers
+	ld a, BANK(EvosAttacksPointers)
+	call LoadDoubleIndirectPointer
+	ld [wStatsScreenFlags], a ; bank
+	call FarSkipEvolutions
+.learnset_loop
+	call GetFarByte
+  	and a
+	jr z, .notfound
+	inc hl
+	call GetFarWord
+	call GetMoveIDFromIndex
+	cp d
+	jr z, .found
+	inc hl
+	inc hl
+	jr .learnset_loop
+
+.found
+	xor a
+	ret ; move is in lvl up learnset
+.notfound
+	scf ; move isnt in lvl up learnset
+	ret
+
+CanUseFlash:
+; Step 1: Badge Check
+;	ld de, ENGINE_ZEPHYRBADGE
+;	ld b, CHECK_FLAG
+;	farcall EngineFlagAction
+;	ld a, c
+;	and a
+;	ret z ; .fail, dont have needed badge
+
+; Step 2: Location Check
+	farcall SpecialAerodactylChamber
+	jr c, .valid_location ; can use flash
+	ld a, [wTimeOfDayPalset]
+	cp DARKNESS_PALSET
+	ret nz ; .fail ; not a darkcave
+
+.valid_location
+; Step 3: Check if Mon knows Move
+	ld hl, FLASH
+	call CheckMonKnowsMove
+	and a
+	jr z, .yes
+
+; Step 4: Check for TM/HM in bag
+	ld a, HM_FLASH
+	ld [wCurItem], a
+	ld hl, wNumItems
+	call CheckItem
+	ret nc ; hm isnt in bag
+
+; Step 5: Check if Mon can learn move from TM/HM/Move Tutor
+	ld hl, FLASH
+	call GetMoveIDFromIndex
+	call CheckMonCanLearn_TM_HM
+	jr c, .yes
+
+; Step 6: Check if Mon can learn move from LVL-UP
+	ld hl, FLASH
+	call GetMoveIDFromIndex
+	call Sub_CheckLvlUpMoves
+	;scf
+	ret c ; fail
+
+.yes
+	ld a, MONMENUITEM_FLASH
+	call AddMonMenuItem
+	ret
+
+CanUseFly:
+; Step 1: Badge Check
+;	ld de, ENGINE_STORMBADGE
+;	ld b, CHECK_FLAG
+;	farcall EngineFlagAction
+;	ld a, c
+;	and a
+;	ret z ; .fail, dont have needed badge
+
+; Step 2: Location Check
+	call GetMapEnvironment
+	call CheckOutdoorMap
+	ret nz ; not outdoors, cant fly
+
+; Step 3: Check if Mon knows Move
+	ld hl, FLY
+	call GetMoveIDFromIndex
+	call CheckMonKnowsMove
+	and a
+	jr z, .yes
+
+; Step 4: Check if HM is in bag
+	ld a, HM_FLY
+	ld [wCurItem], a
+	ld hl, wNumItems
+	call CheckItem
+	ret nc ; .fail, hm isnt in bag
+
+; Step 5: Check if mon can learn move via HM/TM/Move Tutor
+	ld hl, FLY
+	call GetMoveIDFromIndex
+	call CheckMonCanLearn_TM_HM
+	jr c, .yes
+
+; Step 6: Check if Mon can learn move via LVL-UP
+	ld hl, FLY
+	call GetMoveIDFromIndex
+	call Sub_CheckLvlUpMoves
+	;scf
+	ret c ; fail
+.yes
+	ld a, MONMENUITEM_FLY
+	call AddMonMenuItem
+	ret
+
+Can_Use_Sweet_Scent:
+; Step 1: Location check
+	farcall CanEncounterWildMon ; CanUseSweetScent instead for older versions of pokecrystal
+	ret nc
+	farcall GetMapEncounterRate
+	ld a, b
+	and a
+	ret z
+
+.valid_location
+; Step 2: Check if mon knows Move 
+	ld hl, SWEET_SCENT
+	call GetMoveIDFromIndex
+	call CheckMonKnowsMove
+	and a
+	jr z, .yes
+
+; Step 3: Check if TM is in bag
+	ld a, TM_SWEET_SCENT
+	ld [wCurItem], a
+	ld hl, wNumItems
+	call CheckItem
+	ret nc ; .fail, tm not in bag
+
+; Step 4: Check if mon can learn Move via TM/HM/Move tutor
+	ld hl, SWEET_SCENT
+	call GetMoveIDFromIndex
+	call CheckMonCanLearn_TM_HM
+	jr c, .yes
+
+; Step 5: Check if mon can learn move via LVL-UP
+	ld hl, SWEET_SCENT
+	call GetMoveIDFromIndex
+	call Sub_CheckLvlUpMoves
+	;scf
+	ret c ; fail
+.yes
+	ld a, MONMENUITEM_SWEETSCENT
+	call AddMonMenuItem
+	ret
+
+CanUseDig:
+; Step 1: Location Check
+	call GetMapEnvironment
+	cp CAVE
+	jr z, .valid_location
+	cp DUNGEON
+	ret nz ; fail, not inside cave or dungeon
+
+.valid_location
+; Step 2: Check if Mon knows Move
+	ld hl, DIG
+	call GetMoveIDFromIndex
+	call CheckMonKnowsMove
+	and a
+	jr z, .yes
+
+; Step 3: Check if TM/HM is in bag
+	ld a, TM_DIG
+	ld [wCurItem], a
+	ld hl, wNumItems
+	call CheckItem
+	ret nc ; .fail ; TM not in bag
+
+; Step 4: Check if Mon can learn Dig via TM/HM/Move Tutor
+	ld hl, DIG
+	call GetMoveIDFromIndex
+	call CheckMonCanLearn_TM_HM
+	jr c, .yes
+
+; Step 5: Check if Mon can learn move via LVL-UP
+	ld hl, DIG
+	call GetMoveIDFromIndex
+	call Sub_CheckLvlUpMoves
+	;scf
+	ret c ; fail
+.yes
+	ld a, MONMENUITEM_DIG
+	call AddMonMenuItem
+	ret
+
+CanUseTeleport:
+; Step 1: Location Check
+	call GetMapEnvironment
+	call CheckOutdoorMap
+	ret nz ; .fail
+	
+; Step 2: Check if mon knows move
+	ld hl, TELEPORT
+	call GetMoveIDFromIndex
+	call CheckMonKnowsMove
+	and a
+	ret nz
+
+	ld a, MONMENUITEM_TELEPORT
+	call AddMonMenuItem
+	ret
+
+CanUseSoftboiled:
+	ld hl, SOFTBOILED
+	call GetMoveIDFromIndex
+	call CheckMonKnowsMove
+	and a
+	ret nz
+	ld a, MONMENUITEM_SOFTBOILED
+	call AddMonMenuItem
+	ret
+
+CanUseMilkdrink:
+	ld hl, MILK_DRINK
+	call GetMoveIDFromIndex
+	call CheckMonKnowsMove
+	and a
+	ret nz
+
+	ld a, MONMENUITEM_MILKDRINK
+	call AddMonMenuItem
+	ret

--- a/home/hm_moves.asm
+++ b/home/hm_moves.asm
@@ -18,11 +18,11 @@ IsHMMove::
 	jp IsInWordArray
 
 .HMMoves:
-	dw CUT
-	dw FLY
-	dw SURF
-	dw STRENGTH
-	dw FLASH
-	dw WATERFALL
-	dw WHIRLPOOL
+	;dw CUT
+	;dw FLY
+	;dw SURF
+	;dw STRENGTH
+	;dw FLASH
+	;dw WATERFALL
+	;dw WHIRLPOOL
 	dw -1 ; end

--- a/maps/BlackthornPokecenter1F.asm
+++ b/maps/BlackthornPokecenter1F.asm
@@ -44,7 +44,7 @@ BlackthornPokecenter1FTwinText:
 
 	para "So I got the MOVE"
 	line "DELETER to make it"
-	cont "forget an HM move."
+	cont "forget a move."
 	done
 
 BlackthornPokecenter1F_MapEvents:

--- a/maps/CherrygrovePokecenter1F.asm
+++ b/maps/CherrygrovePokecenter1F.asm
@@ -21,7 +21,6 @@ CherrygrovePokecenter1FGentlemanScript:
 CherrygrovePokecenter1FTeacherScript:
 	faceplayer
 	opentext
-	verbosegiveitem HM_SURF
 	checkevent EVENT_GAVE_MYSTERY_EGG_TO_ELM
 	iftrue .CommCenterOpen
 	writetext CherrygrovePokecenter1FTeacherText

--- a/maps/CherrygrovePokecenter1F.asm
+++ b/maps/CherrygrovePokecenter1F.asm
@@ -21,6 +21,7 @@ CherrygrovePokecenter1FGentlemanScript:
 CherrygrovePokecenter1FTeacherScript:
 	faceplayer
 	opentext
+	verbosegiveitem HM_SURF
 	checkevent EVENT_GAVE_MYSTERY_EGG_TO_ELM
 	iftrue .CommCenterOpen
 	writetext CherrygrovePokecenter1FTeacherText


### PR DESCRIPTION
Allow HMs to be forgotten, and allow pokemon to use field move without needing to  learn it.

Note: Bug exists for submenu moves where opening submenu for pokemon can lead to infinite loop. Narrowed down the bug to somewhere in the Sub_CheckLvlUpLearnset code. Unsure how to fix, but for not just commented it out since all mons that can learn a move via level up should also learn it by TM/HM.

Closes #32 